### PR TITLE
add year scope returning year-tag

### DIFF
--- a/pkg/oidcprovider/oidcprovider.go
+++ b/pkg/oidcprovider/oidcprovider.go
@@ -55,7 +55,7 @@ type accessToken struct {
 
 var _ op.Storage = &provider{}
 
-var supportedScopes = []string{"openid", "profile", "email", "offline_access", "pls_*", "permissions", "year"}
+var supportedScopes = []string{"openid", "profile", "email", "offline_access", "pls_*", "permissions", "year_tag"}
 
 func Init(s *service.Service) (http.Handler, error) {
 	// Yes, the initialization of this key does indeed seem very shady. I do
@@ -448,8 +448,8 @@ func setUserinfo(ctx context.Context, userinfo *oidc.UserInfo, user models.User,
 			}
 			userinfo.Claims[scope] = perms
 
-		case "year":
-			userinfo.Claims["year_tag"] = user.YearTag
+		case "year_tag":
+			userinfo.Claims[scope] = user.YearTag
 
 		default:
 			if group, ok := strings.CutPrefix(scope, "pls_"); ok {


### PR DESCRIPTION
adds new oidc scope `"year"` which can return `"year_tag"`