### PR TITLE
Assume yearTag

### DIFF
--- a/handlers/admin.go
+++ b/handlers/admin.go
@@ -387,6 +387,7 @@ func uploadSheet(s *service.Service, w http.ResponseWriter, r *http.Request) htt
 						Email:      email,
 						FirstName:  person.FirstName,
 						FamilyName: person.FamilyName,
+						YearTag:    "D-" + time.Now().Format("06"), // Assume all new ths members are new to kth
 						MemberTo:   pgtype.Date{Valid: true, Time: memberTo},
 					}); err != nil {
 						return err


### PR DESCRIPTION
When uploading the membership sheet assume that every new student just joined kth (was nollan). This will not always be true but should be most of the time. There are other options, like uploading a list of this years nollan to set the yearTag, but I think that the number of incorrectly tagged individuals should be low enough that it wont matter