### PR TITLE
Migrate SSO:s own permission system to Hive

### DIFF
--- a/cmd/web/web.go
+++ b/cmd/web/web.go
@@ -57,7 +57,7 @@ func serve(s *service.Service, op http.Handler, internal bool, p int) {
 	if internal {
 		started = "Internal server started"
 	}
-	slog.Info(started, "address", "http://localhost:"+port)
+	slog.Info(started, "address", "http://localhost:"+port, "config", config.Config)
 	slog.Error("Failed serving http server", "error", http.Serve(l, mux))
 	os.Exit(1)
 }

--- a/database/migrations/20250915133739_store_permissions_in_sessions.sql
+++ b/database/migrations/20250915133739_store_permissions_in_sessions.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+delete from sessions;
+alter table sessions
+add column permissions json not null;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+alter table sessions
+drop column permissions;
+-- +goose StatementEnd

--- a/database/models.go
+++ b/database/models.go
@@ -53,9 +53,10 @@ type Passkey struct {
 }
 
 type Session struct {
-	ID         uuid.UUID
-	Kthid      string
-	LastUsedAt pgtype.Timestamp
+	ID          uuid.UUID
+	Kthid       string
+	LastUsedAt  pgtype.Timestamp
+	Permissions []byte
 }
 
 type User struct {

--- a/database/sql/user.sql
+++ b/database/sql/user.sql
@@ -1,6 +1,6 @@
 -- name: CreateSession :one
-insert into sessions (kthid)
-values ($1)
+insert into sessions (kthid, permissions)
+values ($1, $2)
 returning id;
 
 -- name: GetSession :one
@@ -8,7 +8,7 @@ update sessions
 set last_used_at = now()
 where id = $1
 and last_used_at > now() - interval '8 hours'
-returning kthid;
+returning kthid, permissions;
 
 -- name: RemoveSession :exec
 delete from sessions

--- a/handlers/authorization.go
+++ b/handlers/authorization.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"reflect"
+
+	"github.com/datasektionen/sso/pkg/hive"
+	"github.com/datasektionen/sso/pkg/httputil"
+	"github.com/datasektionen/sso/service"
+)
+
+func authorize(s *service.Service, h http.Handler, permID string, scopeGetter func(*http.Request) string) http.Handler {
+	return httputil.Route(s, func(s *service.Service, w http.ResponseWriter, r *http.Request) httputil.ToResponse {
+		kthid, err := s.GetLoggedInKTHID(r)
+		if err != nil {
+			return err
+		}
+		if kthid == "" {
+			s.RedirectToLogin(w, r, r.URL.Path)
+			return nil
+		}
+		perms, err := hive.GetSSOPermissions(r.Context(), kthid)
+		if err != nil {
+			return err
+		}
+		permType := reflect.TypeFor[hive.Permissions]()
+		permValue := reflect.ValueOf(&perms).Elem()
+		var allowed, foundPerm bool
+		for i := 0; i < permType.NumField(); i++ {
+			field := permType.Field(i)
+			tag := field.Tag.Get("hive")
+			if tag != permID {
+				continue
+			}
+			foundPerm = true
+			fieldValue := permValue.Field(i)
+			if scopes, ok := fieldValue.Addr().Interface().(*hive.PermissionScopes); ok {
+				allowed = scopes.Matches(scopeGetter(r))
+			} else if a, ok := fieldValue.Interface().(bool); ok {
+				allowed = a
+			} else {
+				panic("Unknown permission type")
+			}
+			break
+		}
+		if !foundPerm {
+			return fmt.Errorf("Tried checking for non-existing Hive permission with ID '%s'", permID)
+		}
+		if !allowed {
+			return httputil.Forbidden("Missing Hive permission " + permID)
+		}
+
+		r = r.WithContext(context.WithValue(r.Context(), hive.Permissions{}, perms))
+
+		h.ServeHTTP(w, r)
+
+		if r.Method != http.MethodGet {
+			args := []any{"kthid", kthid, "method", r.Method, "path", r.URL.Path}
+			if id := r.PathValue("id"); id != "" {
+				args = append(args, "id", id)
+			} else if r.Form != nil && r.Form.Has("id") {
+				args = append(args, "id", r.Form.Get("id"))
+			}
+			slog.InfoContext(r.Context(), "Admin action taken", args...)
+		}
+
+		return nil
+	})
+}

--- a/handlers/dev.go
+++ b/handlers/dev.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/datasektionen/sso/pkg/auth"
 	"github.com/datasektionen/sso/pkg/httputil"
 	"github.com/datasektionen/sso/service"
 )
@@ -18,17 +17,7 @@ func devLogin(s *service.Service, w http.ResponseWriter, r *http.Request) httput
 	if user == nil {
 		return httputil.BadRequest("No such user")
 	}
-	sessionID, err := s.DB.CreateSession(r.Context(), user.KTHID)
-	if err != nil {
-		return err
-	}
-	http.SetCookie(w, &http.Cookie{
-		Name:  auth.SessionCookieName,
-		Value: sessionID.String(),
-		Path:  "/",
-	})
-	http.Redirect(w, r, "/", http.StatusSeeOther)
-	return nil
+	return s.LoginUser(r.Context(), user.KTHID)
 }
 
 func autoReload(s *service.Service, w http.ResponseWriter, r *http.Request) httputil.ToResponse {

--- a/handlers/legacyapi.go
+++ b/handlers/legacyapi.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/datasektionen/sso/pkg/config"
 	"github.com/datasektionen/sso/pkg/httputil"
 	"github.com/datasektionen/sso/pkg/pls"
 	"github.com/datasektionen/sso/service"
@@ -47,7 +48,7 @@ func legacyAPILogin(s *service.Service, w http.ResponseWriter, r *http.Request) 
 		Value:    callback.String(),
 		Path:     "/legacyapi",
 		MaxAge:   int((time.Minute * 10).Seconds()),
-		Secure:   true,
+		Secure:   !config.Config.Dev,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 	})

--- a/handlers/legacyapi.go
+++ b/handlers/legacyapi.go
@@ -60,10 +60,7 @@ func legacyAPICallback(s *service.Service, w http.ResponseWriter, r *http.Reques
 	if callback == nil {
 		return httputil.BadRequest("Idk where you came from. Maybe you took longer than 10 minutes?")
 	}
-	user, err := s.GetLoggedInUser(r)
-	if err != nil {
-		return err
-	}
+	user := s.GetLoggedInUser(r)
 	if user == nil {
 		return httputil.BadRequest("You did not seem to get logged in")
 	}
@@ -105,10 +102,7 @@ func legacyAPIVerify(s *service.Service, w http.ResponseWriter, r *http.Request)
 }
 
 func legacyAPILogout(s *service.Service, w http.ResponseWriter, r *http.Request) httputil.ToResponse {
-	user, err := s.GetLoggedInUser(r)
-	if err != nil {
-		return err
-	}
+	user := s.GetLoggedInUser(r)
 	if user != nil {
 		if err := s.DB.DeleteToken(r.Context(), user.KTHID); err != nil {
 			return err

--- a/handlers/passkey.go
+++ b/handlers/passkey.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/datasektionen/sso/database"
 	"github.com/datasektionen/sso/models"
-	"github.com/datasektionen/sso/pkg/auth"
 	"github.com/datasektionen/sso/pkg/httputil"
 	"github.com/datasektionen/sso/service"
 	"github.com/datasektionen/sso/templates"
@@ -89,21 +88,11 @@ func finishLoginPasskey(s *service.Service, w http.ResponseWriter, r *http.Reque
 		return err
 	}
 
-	sessionID, err := s.DB.CreateSession(r.Context(), user.KTHID)
-	if err != nil {
-		return err
-	}
-
-	http.SetCookie(w, auth.SessionCookie(sessionID.String()))
-
-	return nil
+	return s.LoginUser(r.Context(), user.KTHID)
 }
 
 func addPasskeyForm(s *service.Service, w http.ResponseWriter, r *http.Request) httputil.ToResponse {
-	user, err := s.GetLoggedInUser(r)
-	if err != nil {
-		return err
-	}
+	user := s.GetLoggedInUser(r)
 	if user == nil {
 		return httputil.Unauthorized()
 	}
@@ -126,10 +115,7 @@ func addPasskeyForm(s *service.Service, w http.ResponseWriter, r *http.Request) 
 }
 
 func addPasskey(s *service.Service, w http.ResponseWriter, r *http.Request) httputil.ToResponse {
-	user, err := s.GetLoggedInUser(r)
-	if err != nil {
-		return err
-	}
+	user := s.GetLoggedInUser(r)
 	if user == nil {
 		return httputil.Unauthorized()
 	}
@@ -178,10 +164,7 @@ func addPasskey(s *service.Service, w http.ResponseWriter, r *http.Request) http
 }
 
 func removePasskey(s *service.Service, w http.ResponseWriter, r *http.Request) httputil.ToResponse {
-	user, err := s.GetLoggedInUser(r)
-	if err != nil {
-		return err
-	}
+	user := s.GetLoggedInUser(r)
 	if user == nil {
 		return httputil.Unauthorized()
 	}

--- a/handlers/routes.go
+++ b/handlers/routes.go
@@ -24,30 +24,30 @@ func MountRoutes(s *service.Service, mux *http.ServeMux, includeInternal bool) {
 	mux.Handle("GET /invite/{id}", httputil.Route(s, acceptInvite))
 
 	// admin.go
-	mux.Handle("GET /admin", authAdmin(s, httputil.Route(s, admin)))
+	mux.Handle("GET /admin", authorize(s, httputil.Route(s, admin), "read-members", nil))
 
-	mux.Handle("GET /admin/members", authAdmin(s, httputil.Route(s, membersPage)))
-	mux.Handle("GET /admin/users", authAdmin(s, httputil.Route(s, adminUsersForm)))
-	mux.Handle("POST /admin/members/upload-sheet", authAdmin(s, httputil.Route(s, uploadSheet)))
-	mux.Handle("GET /admin/members/upload-sheet", authAdmin(s, httputil.Route(s, processSheet)))
+	mux.Handle("GET /admin/members", authorize(s, httputil.Route(s, membersPage), "read-members", nil))
+	mux.Handle("GET /admin/users", authorize(s, httputil.Route(s, adminUsersForm), "read-members", nil))
+	mux.Handle("POST /admin/members/upload-sheet", authorize(s, httputil.Route(s, uploadSheet), "write-members", nil))
+	mux.Handle("GET /admin/members/upload-sheet", authorize(s, httputil.Route(s, processSheet), "write-members", nil))
 
-	mux.Handle("GET /admin/oidc-clients", authAdmin(s, httputil.Route(s, oidcClients)))
-	mux.Handle("POST /admin/oidc-clients", authAdmin(s, httputil.Route(s, createOIDCClient)))
-	mux.Handle("PATCH /admin/oidc-clients/{id}", authAdmin(s, httputil.Route(s, updateOIDCClient)))
-	mux.Handle("DELETE /admin/oidc-clients/{id}", authAdmin(s, httputil.Route(s, deleteOIDCClient)))
-	mux.Handle("POST /admin/oidc-clients/{id}/redirect-uris", authAdmin(s, httputil.Route(s, addRedirectURI)))
-	mux.Handle("DELETE /admin/oidc-clients/{id}/redirect-uris/{uri}", authAdmin(s, httputil.Route(s, removeRedirectURI)))
+	mux.Handle("GET /admin/oidc-clients", authorize(s, httputil.Route(s, oidcClients), "read-oidc-clients", nil))
+	mux.Handle("POST /admin/oidc-clients", authorize(s, httputil.Route(s, createOIDCClient), "write-oidc-clients", func(r *http.Request) string { return r.FormValue("id") }))
+	mux.Handle("PATCH /admin/oidc-clients/{id}", authorize(s, httputil.Route(s, updateOIDCClient), "write-oidc-clients", func(r *http.Request) string { return r.PathValue("id") }))
+	mux.Handle("DELETE /admin/oidc-clients/{id}", authorize(s, httputil.Route(s, deleteOIDCClient), "write-oidc-clients", func(r *http.Request) string { return r.PathValue("id") }))
+	mux.Handle("POST /admin/oidc-clients/{id}/redirect-uris", authorize(s, httputil.Route(s, addRedirectURI), "write-oidc-clients", func(r *http.Request) string { return r.PathValue("id") }))
+	mux.Handle("DELETE /admin/oidc-clients/{id}/redirect-uris/{uri}", authorize(s, httputil.Route(s, removeRedirectURI), "write-oidc-clients", func(r *http.Request) string { return r.PathValue("id") }))
 
-	mux.Handle("GET /admin/invites", authAdmin(s, httputil.Route(s, invites)))
-	mux.Handle("GET /admin/invites/{id}", authAdmin(s, httputil.Route(s, invite)))
-	mux.Handle("POST /admin/invites", authAdmin(s, httputil.Route(s, createInvite)))
-	mux.Handle("DELETE /admin/invites/{id}", authAdmin(s, httputil.Route(s, deleteInvite)))
-	mux.Handle("GET /admin/invites/{id}/edit", authAdmin(s, httputil.Route(s, editInviteForm)))
-	mux.Handle("PUT /admin/invites/{id}", authAdmin(s, httputil.Route(s, updateInvite)))
+	mux.Handle("GET /admin/invites", authorize(s, httputil.Route(s, invites), "read-invites", nil))
+	mux.Handle("GET /admin/invites/{id}", authorize(s, httputil.Route(s, invite), "read-invites", nil))
+	mux.Handle("POST /admin/invites", authorize(s, httputil.Route(s, createInvite), "write-invites", nil))
+	mux.Handle("DELETE /admin/invites/{id}", authorize(s, httputil.Route(s, deleteInvite), "write-invites", nil))
+	mux.Handle("GET /admin/invites/{id}/edit", authorize(s, httputil.Route(s, editInviteForm), "write-invites", nil))
+	mux.Handle("PUT /admin/invites/{id}", authorize(s, httputil.Route(s, updateInvite), "write-invites", nil))
 
-	mux.Handle("GET /admin/account-requests", authAdmin(s, httputil.Route(s, accountRequests)))
-	mux.Handle("DELETE /admin/account-requests/{id}", authAdmin(s, httputil.Route(s, denyAccountRequest)))
-	mux.Handle("POST /admin/account-requests/{id}", authAdmin(s, httputil.Route(s, approveAccountRequest)))
+	mux.Handle("GET /admin/account-requests", authorize(s, httputil.Route(s, accountRequests), "read-account-requests", nil))
+	mux.Handle("DELETE /admin/account-requests/{id}", authorize(s, httputil.Route(s, denyAccountRequest), "manage-account-requests", nil))
+	mux.Handle("POST /admin/account-requests/{id}", authorize(s, httputil.Route(s, approveAccountRequest), "manage-account, requests", nil))
 
 	// dev.go
 	if config.Config.Dev {

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/datasektionen/sso/database"
 	"github.com/datasektionen/sso/pkg/httputil"
-	"github.com/datasektionen/sso/pkg/pls"
 	"github.com/datasektionen/sso/service"
 	"github.com/datasektionen/sso/templates"
 	"github.com/google/uuid"
@@ -86,11 +85,12 @@ func account(s *service.Service, w http.ResponseWriter, r *http.Request) httputi
 	if err != nil {
 		return err
 	}
-	isAdmin, err := pls.CheckUser(r.Context(), user.KTHID, "admin-read")
-	if err != nil {
-		return err
-	}
-	return templates.Account(*user, passkeys, isAdmin)
+	// TODO:
+	// perms, err := hive.GetSSOPermissions(r.Context(), user.KTHID)
+	// if err != nil {
+	// 	return err
+	// }
+	return templates.Account(*user, passkeys)
 }
 
 var yearTagRegex regexp.Regexp = *regexp.MustCompile(`^[A-Z][A-Za-z]{0,3}-\d{2}$`)

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -46,9 +46,8 @@ func index(s *service.Service, w http.ResponseWriter, r *http.Request) httputil.
 	if nextURL == "" {
 		nextURL = "/account"
 	}
-	if kthid, err := s.GetLoggedInKTHID(r); err != nil {
-		return err
-	} else if kthid != "" {
+	user := s.GetLoggedInUser(r)
+	if user != nil {
 		if hasCookie {
 			http.SetCookie(w, &http.Cookie{Name: nextUrlCookie, MaxAge: -1})
 		}
@@ -65,7 +64,7 @@ func index(s *service.Service, w http.ResponseWriter, r *http.Request) httputil.
 			SameSite: http.SameSiteLaxMode,
 		})
 	}
-	return templates.Index(s.DevLoginForm)
+	return templates.Index(s.DevLoginFormOrNilComp)
 }
 
 func logout(s *service.Service, w http.ResponseWriter, r *http.Request) httputil.ToResponse {
@@ -73,10 +72,7 @@ func logout(s *service.Service, w http.ResponseWriter, r *http.Request) httputil
 }
 
 func account(s *service.Service, w http.ResponseWriter, r *http.Request) httputil.ToResponse {
-	user, err := s.GetLoggedInUser(r)
-	if err != nil {
-		return err
-	}
+	user := s.GetLoggedInUser(r)
 	if user == nil {
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 		return nil
@@ -96,10 +92,7 @@ func account(s *service.Service, w http.ResponseWriter, r *http.Request) httputi
 var yearTagRegex regexp.Regexp = *regexp.MustCompile(`^[A-Z][A-Za-z]{0,3}-\d{2}$`)
 
 func updateAccount(s *service.Service, w http.ResponseWriter, r *http.Request) httputil.ToResponse {
-	user, err := s.GetLoggedInUser(r)
-	if err != nil {
-		return err
-	}
+	user := s.GetLoggedInUser(r)
 	if user == nil {
 		return httputil.Unauthorized()
 	}

--- a/handlers/user.go
+++ b/handlers/user.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/datasektionen/sso/database"
+	"github.com/datasektionen/sso/pkg/config"
 	"github.com/datasektionen/sso/pkg/httputil"
 	"github.com/datasektionen/sso/service"
 	"github.com/datasektionen/sso/templates"
@@ -59,7 +60,7 @@ func index(s *service.Service, w http.ResponseWriter, r *http.Request) httputil.
 			Name:     nextUrlCookie,
 			Value:    nextURL,
 			MaxAge:   int((time.Minute * 10).Seconds()),
-			Secure:   true,
+			Secure:   !config.Config.Dev,
 			HttpOnly: true,
 			SameSite: http.SameSiteLaxMode,
 		})
@@ -162,7 +163,7 @@ func requestAccount(s *service.Service, w http.ResponseWriter, r *http.Request) 
 		http.SetCookie(w, &http.Cookie{
 			Name:     "account-request-id",
 			Value:    id.String(),
-			Secure:   true,
+			Secure:   !config.Config.Dev,
 			HttpOnly: true,
 			SameSite: http.SameSiteLaxMode,
 		})
@@ -204,7 +205,7 @@ func acceptInvite(s *service.Service, w http.ResponseWriter, r *http.Request) ht
 	http.SetCookie(w, &http.Cookie{
 		Name:     "invite",
 		Value:    id.String(),
-		Secure:   true,
+		Secure:   !config.Config.Dev,
 		HttpOnly: true,
 		Path:     "/",
 		SameSite: http.SameSiteLaxMode,

--- a/models/user.go
+++ b/models/user.go
@@ -14,3 +14,5 @@ type User struct {
 	FirstNameChangeRequest  string
 	FamilyNameChangeRequest string
 }
+
+type UserCtxKey struct{}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,6 +1,10 @@
 package auth
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/datasektionen/sso/pkg/config"
+)
 
 const SessionCookieName string = "_sso_session"
 
@@ -10,7 +14,7 @@ func SessionCookie(sessionID string) *http.Cookie {
 		Value:    sessionID,
 		Path:     "/",
 		HttpOnly: true,
-		Secure:   true,
+		Secure:   !config.Config.Dev,
 		SameSite: http.SameSiteLaxMode,
 	}
 }

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -7,13 +7,80 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/datasektionen/sso/pkg/config"
 )
 
+type ScopedPermission struct {
+	Scopes []string
+}
+
+func (sp ScopedPermission) Matches(entity string) bool {
+	for _, scope := range sp.Scopes {
+		if base, ok := strings.CutSuffix(scope, "*"); ok {
+			if strings.HasPrefix(entity, base) {
+				return true
+			}
+		} else {
+			if entity == scope {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+type Permissions struct {
+	ReadMembers           bool
+	WriteMembers          bool
+	ReadOIDCClients       bool
+	WriteOIDCClients      ScopedPermission
+	ReadInvites           bool
+	WriteInvites          bool
+	ReadAccountRequests   bool
+	ManageAccountRequests bool
+}
+
+func GetSSOPermissions(ctx context.Context, kthid string) (Permissions, error) {
+	rawPerms, err := GetRawPermissionsInSystemForUser(ctx, kthid, "sso")
+	if err != nil {
+		return Permissions{}, err
+	}
+
+	var perms Permissions
+	for _, perm := range rawPerms {
+		switch perm.ID {
+		case "read-members":
+			perms.ReadMembers = true
+		case "write-members":
+			perms.WriteMembers = true
+		case "read-oidc-clients":
+			perms.ReadOIDCClients = true
+		case "write-oidc-clients":
+			perms.WriteOIDCClients.Scopes = append(perms.WriteOIDCClients.Scopes, perm.Scope)
+		case "read-invites":
+			perms.ReadInvites = true
+		case "write-invites":
+			perms.WriteInvites = true
+		case "read-account-requests":
+			perms.ReadAccountRequests = true
+		case "manage-account-requests":
+			perms.ManageAccountRequests = true
+		}
+	}
+
+	return perms, err
+}
+
+type RawPermission struct {
+	ID    string `json:"id"`
+	Scope string `json:"scope"`
+}
+
 // Result follows the format described in the hive documentation. E.g.:
 // [ { "id": "attest", "scope": "*" }, { "id": "view-logs", "scope": null }, { "id": "write", "scope": "/central/flag.txt" } ]
-func GetPermissionsInSystemForUser(ctx context.Context, kthid string, system string) (any, error) {
+func GetRawPermissionsInSystemForUser(ctx context.Context, kthid string, system string) ([]RawPermission, error) {
 	if config.Config.HiveURL == nil || config.Config.HiveAPIKey == "" {
 		return nil, fmt.Errorf("URL or API key to hive missing in env variables, so cannot fetch permissions from hive")
 	}
@@ -35,7 +102,7 @@ func GetPermissionsInSystemForUser(ctx context.Context, kthid string, system str
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("Unexpected status code from hive: %d", resp.StatusCode)
 	}
-	var body any
+	var body []RawPermission
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		return nil, fmt.Errorf("Invalid JSON from hive: %w", err)
 	}

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -43,6 +42,8 @@ type Permissions struct {
 	ManageAccountRequests bool             `hive:"manage-account-requests"`
 }
 
+type PermissionsCtxKey struct{}
+
 func GetSSOPermissions(ctx context.Context, kthid string) (Permissions, error) {
 	rawPerms, err := GetRawPermissionsInSystemForUser(ctx, kthid, "sso")
 	if err != nil {
@@ -61,6 +62,7 @@ func GetSSOPermissions(ctx context.Context, kthid string) (Permissions, error) {
 			if tag != perm.ID {
 				continue
 			}
+			foundField = true
 			fieldValue := permValue.Field(i)
 
 			if scopes, ok := fieldValue.Addr().Interface().(*PermissionScopes); ok {
@@ -101,7 +103,6 @@ func GetRawPermissionsInSystemForUser(ctx context.Context, kthid string, system 
 	if err != nil {
 		return nil, err
 	}
-	slog.Info("hive getPermissions", "url", req)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -54,9 +54,15 @@ func Respond(resp ToResponse, w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func Route[S any](s S, f func(s S, w http.ResponseWriter, r *http.Request) ToResponse) http.Handler {
+func Route[S interface {
+	WithSession(r *http.Request) (*http.Request, error)
+}](s S, f func(s S, w http.ResponseWriter, r *http.Request) ToResponse) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		Respond(f(s, w, r), w, r)
+		r2, err := s.WithSession(r)
+		if err != nil {
+			Respond(err, w, r)
+		}
+		Respond(f(s, w, r2), w, r2)
 	})
 }
 

--- a/pkg/oidcprovider/oidcprovider.go
+++ b/pkg/oidcprovider/oidcprovider.go
@@ -441,7 +441,7 @@ func setUserinfo(ctx context.Context, userinfo *oidc.UserInfo, user models.User,
 			if system == "" {
 				return httputil.BadRequest("Hive System ID must be set in the admin console when requesting permissions through OIDC")
 			}
-			perms, err := hive.GetPermissionsInSystemForUser(ctx, user.KTHID, system)
+			perms, err := hive.GetRawPermissionsInSystemForUser(ctx, user.KTHID, system)
 			if err != nil {
 				slog.Error("setUserinfo: error getting permissions", "err", err)
 				return err

--- a/service/dev.go
+++ b/service/dev.go
@@ -9,7 +9,7 @@ import (
 	"github.com/datasektionen/sso/templates"
 )
 
-func (s *Service) DevLoginForm() templ.Component {
+func (s *Service) DevLoginFormOrNilComp() templ.Component {
 	if !config.Config.Dev {
 		return templ.ComponentFunc(func(ctx context.Context, w io.Writer) error {
 			return nil

--- a/templates/admin.templ
+++ b/templates/admin.templ
@@ -8,7 +8,7 @@ import (
 )
 
 templ adminNav() {
-	{{ perms := ctx.Value(hive.Permissions{}).(hive.Permissions) }}
+	{{ perms := ctx.Value(hive.PermissionsCtxKey{}).(hive.Permissions) }}
 	if perms.ReadMembers {
 		<a href="/admin/members">Members</a>
 	}

--- a/templates/admin.templ
+++ b/templates/admin.templ
@@ -3,18 +3,28 @@ package templates
 import (
 	"fmt"
 	"github.com/datasektionen/sso/models"
+	"github.com/datasektionen/sso/pkg/hive"
 	"time"
 )
 
 templ adminNav() {
-	<a href="/admin/members">Members</a>
-	<a href="/admin/oidc-clients">OIDC Clients</a>
-	<a href="/admin/invites">Invites</a>
-	<a href="/admin/account-requests">Account Requests</a>
+	{{ perms := ctx.Value(hive.Permissions{}).(hive.Permissions) }}
+	if perms.ReadMembers {
+		<a href="/admin/members">Members</a>
+	}
+	if perms.ReadOIDCClients {
+		<a href="/admin/oidc-clients">OIDC Clients</a>
+	}
+	if perms.ReadInvites {
+		<a href="/admin/invites">Invites</a>
+	}
+	if perms.ReadAccountRequests {
+		<a href="/admin/account-requests">Account Requests</a>
+	}
 }
 
 templ AdminPage() {
-	@page(nav(true)) {
+	@page(nav()) {
 		{ children... }
 	}
 }
@@ -111,7 +121,7 @@ templ uploadForm(lastUpdatedAt time.Time) {
 		hx-swap="outerHTML"
 		hx-target="#upload-status"
 	>
-		<p class="shrink-0">Upload THS membership sheet. Last upload at {lastUpdatedAt.Format(time.DateOnly)}</p>
+		<p class="shrink-0">Upload THS membership sheet. Last upload at { lastUpdatedAt.Format(time.DateOnly) }</p>
 		<input
 			name="sheet"
 			type="file"

--- a/templates/admin_templ.go
+++ b/templates/admin_templ.go
@@ -36,7 +36,7 @@ func adminNav() templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		perms := ctx.Value(hive.Permissions{}).(hive.Permissions)
+		perms := ctx.Value(hive.PermissionsCtxKey{}).(hive.Permissions)
 		if perms.ReadMembers {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<a href=\"/admin/members\">Members</a> ")
 			if templ_7745c5c3_Err != nil {

--- a/templates/admin_templ.go
+++ b/templates/admin_templ.go
@@ -11,6 +11,7 @@ import templruntime "github.com/a-h/templ/runtime"
 import (
 	"fmt"
 	"github.com/datasektionen/sso/models"
+	"github.com/datasektionen/sso/pkg/hive"
 	"time"
 )
 
@@ -35,9 +36,30 @@ func adminNav() templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<a href=\"/admin/members\">Members</a> <a href=\"/admin/oidc-clients\">OIDC Clients</a> <a href=\"/admin/invites\">Invites</a> <a href=\"/admin/account-requests\">Account Requests</a>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
+		perms := ctx.Value(hive.Permissions{}).(hive.Permissions)
+		if perms.ReadMembers {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<a href=\"/admin/members\">Members</a> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if perms.ReadOIDCClients {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<a href=\"/admin/oidc-clients\">OIDC Clients</a> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if perms.ReadInvites {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<a href=\"/admin/invites\">Invites</a> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if perms.ReadAccountRequests {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<a href=\"/admin/account-requests\">Account Requests</a>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
 		return nil
 	})
@@ -82,7 +104,7 @@ func AdminPage() templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = page(nav(true)).Render(templ.WithChildren(ctx, templ_7745c5c3_Var3), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = page(nav()).Render(templ.WithChildren(ctx, templ_7745c5c3_Var3), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -123,7 +145,7 @@ func Members(lastUpdatedAt time.Time) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"p-8\"><section hx-get=\"/admin/users\" hx-trigger=\"load\" hx-swap=\"morph:innerHTML\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"p-8\"><section hx-get=\"/admin/users\" hx-trigger=\"load\" hx-swap=\"morph:innerHTML\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -131,7 +153,7 @@ func Members(lastUpdatedAt time.Time) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</section>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -143,7 +165,7 @@ func Members(lastUpdatedAt time.Time) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -178,60 +200,21 @@ func MemberList(users []models.User, search string, offset int, more bool, years
 			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"grid grid-cols-[repeat(4,auto)] gap-x-2 *:h-7\"><div class=\"grid grid-cols-subgrid col-span-full\"><span>Username</span> <span>Name</span> <span>Year</span> <span>Member until</span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"grid grid-cols-[repeat(4,auto)] gap-x-2 *:h-7\"><div class=\"grid grid-cols-subgrid col-span-full\"><span>Username</span> <span>Name</span> <span>Year</span> <span>Member until</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, user := range users {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div class=\"grid grid-cols-subgrid col-span-full\"><span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div class=\"grid grid-cols-subgrid col-span-full\"><span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(user.KTHID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 44, Col: 22}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 54, Col: 22}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</span> <span>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var8 string
-			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(user.FirstName)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 45, Col: 26}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, " ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var9 string
-			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(user.FamilyName)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 45, Col: 46}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</span> <span>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var10 string
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(user.YearTag)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 46, Col: 24}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -239,29 +222,68 @@ func MemberList(users []models.User, search string, offset int, more bool, years
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
+			var templ_7745c5c3_Var8 string
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(user.FirstName)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 55, Col: 26}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var9 string
+			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(user.FamilyName)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 55, Col: 46}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</span> <span>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var10 string
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(user.YearTag)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 56, Col: 24}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</span> <span>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 			if user.MemberTo != (time.Time{}) {
 				var templ_7745c5c3_Var11 string
 				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(user.MemberTo.Format(time.DateOnly))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 49, Col: 43}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 59, Col: 43}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		for i := len(users); i < 20; i++ {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div class=\"grid grid-cols-subgrid col-span-full\"></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div class=\"grid grid-cols-subgrid col-span-full\"></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</div><div class=\"flex gap-2 pt-2\" hx-target=\"closest section\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div><div class=\"flex gap-2 pt-2\" hx-target=\"closest section\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -270,7 +292,7 @@ func MemberList(users []models.User, search string, offset int, more bool, years
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<input hx-get=\"/admin/users\" type=\"text\" name=\"search\" placeholder=\"Search...\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<input hx-get=\"/admin/users\" type=\"text\" name=\"search\" placeholder=\"Search...\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -283,30 +305,30 @@ func MemberList(users []models.User, search string, offset int, more bool, years
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(search)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 65, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 75, Col: 17}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if search != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, " autofocus")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, " autofocus")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -315,7 +337,7 @@ func MemberList(users []models.User, search string, offset int, more bool, years
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<select hx-get=\"/admin/users\" name=\"year\" hx-include=\"input[name=&#34;search&#34;]\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<select hx-get=\"/admin/users\" name=\"year\" hx-include=\"input[name=&#34;search&#34;]\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -328,40 +350,40 @@ func MemberList(users []models.User, search string, offset int, more bool, years
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\"><option value=\"\">Year</option> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\"><option value=\"\">Year</option> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, year := range years {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<option")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<option")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if year == selectedYear {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, " selected")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, " selected")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, ">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, ">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var17 string
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(year)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 82, Col: 11}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 92, Col: 11}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</option>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</option>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</select> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</select> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -370,7 +392,7 @@ func MemberList(users []models.User, search string, offset int, more bool, years
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<button hx-get=\"/admin/users\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<button hx-get=\"/admin/users\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -383,30 +405,30 @@ func MemberList(users []models.User, search string, offset int, more bool, years
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\" hx-vals=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" hx-vals=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(templ.JSONString(map[string]any{"offset": max(0, offset-20)}))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 88, Col: 74}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 98, Col: 74}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" hx-include=\"input[name=&#34;search&#34;], select[name=&#34;year&#34;]\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" hx-include=\"input[name=&#34;search&#34;], select[name=&#34;year&#34;]\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if offset == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " disabled")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, " disabled")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, ">prev</button> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, ">prev</button> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -415,7 +437,7 @@ func MemberList(users []models.User, search string, offset int, more bool, years
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<button hx-get=\"/admin/users\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<button hx-get=\"/admin/users\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -428,30 +450,30 @@ func MemberList(users []models.User, search string, offset int, more bool, years
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" hx-vals=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\" hx-vals=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var23 string
 		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(templ.JSONString(map[string]any{"offset": offset + 20}))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 97, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 107, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\" hx-include=\"input[name=&#34;search&#34;], select[name=&#34;year&#34;]\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\" hx-include=\"input[name=&#34;search&#34;], select[name=&#34;year&#34;]\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if !more {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, " disabled")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, " disabled")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, ">next</button></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, ">next</button></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -480,20 +502,20 @@ func uploadForm(lastUpdatedAt time.Time) templ.Component {
 			templ_7745c5c3_Var24 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<form class=\"py-2 flex gap-2 items-center\" hx-post=\"/admin/members/upload-sheet\" hx-encoding=\"multipart/form-data\" hx-swap=\"outerHTML\" hx-target=\"#upload-status\"><p class=\"shrink-0\">Upload THS membership sheet. Last upload at ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<form class=\"py-2 flex gap-2 items-center\" hx-post=\"/admin/members/upload-sheet\" hx-encoding=\"multipart/form-data\" hx-swap=\"outerHTML\" hx-target=\"#upload-status\"><p class=\"shrink-0\">Upload THS membership sheet. Last upload at ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var25 string
 		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(lastUpdatedAt.Format(time.DateOnly))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 114, Col: 102}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 124, Col: 103}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</p><input name=\"sheet\" type=\"file\" required class=\"\n\t\t\t\tbg-[#3f4c66] rounded p-1 grid place-items-center pointer w-full\n\t\t\t\tborder border-transparent outline-none focus:border-cerisestrong hover:border-ceriselight relative\n\t\t\t\"> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "</p><input name=\"sheet\" type=\"file\" required class=\"\n\t\t\t\tbg-[#3f4c66] rounded p-1 grid place-items-center pointer w-full\n\t\t\t\tborder border-transparent outline-none focus:border-cerisestrong hover:border-ceriselight relative\n\t\t\t\"> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -502,7 +524,7 @@ func uploadForm(lastUpdatedAt time.Time) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<button class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<button class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -515,7 +537,7 @@ func uploadForm(lastUpdatedAt time.Time) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "\">Upload</button></form>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\">Upload</button></form>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -545,12 +567,12 @@ func UploadStatus(withStuff bool) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		if withStuff {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<div id=\"upload-status\" class=\"w-full\" hx-ext=\"sse\" sse-connect=\"/admin/members/upload-sheet\"><div sse-swap=\"progress\" hx-swap=\"innerHTML\" class=\"w-full h-1 bg-white\"></div><div class=\"flex flex-col gap-2 pt-2\" sse-swap=\"message\" hx-swap=\"beforeend\"></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<div id=\"upload-status\" class=\"w-full\" hx-ext=\"sse\" sse-connect=\"/admin/members/upload-sheet\"><div sse-swap=\"progress\" hx-swap=\"innerHTML\" class=\"w-full h-1 bg-white\"></div><div class=\"flex flex-col gap-2 pt-2\" sse-swap=\"message\" hx-swap=\"beforeend\"></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<div id=\"upload-status\"></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "<div id=\"upload-status\"></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -580,7 +602,7 @@ func UploadProgress(progress float64) templ.Component {
 			templ_7745c5c3_Var29 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<div class=\"bg-ceriseregular h-full\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<div class=\"bg-ceriseregular h-full\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -588,7 +610,7 @@ func UploadProgress(progress float64) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -622,7 +644,7 @@ func UploadMessage(message string, isErr bool) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "<p class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<p class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -635,20 +657,20 @@ func UploadMessage(message string, isErr bool) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var33 string
 		templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 151, Col: 93}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `admin.templ`, Line: 161, Col: 93}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/templates/dev.templ
+++ b/templates/dev.templ
@@ -41,7 +41,7 @@ templ devAutoReload() {
 				const res = await fetch("/ping");
 				await res.text();
 				location.reload();
-			} catch () {
+			} catch (_) {
 				setTimeout(f, 200);
 			}
 		};

--- a/templates/dev_templ.go
+++ b/templates/dev_templ.go
@@ -58,7 +58,7 @@ func devAutoReload() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<script type=\"module\">\n\t\tlet data = undefined;\n\t\tlet es = new EventSource(\"/dev/auto-reload\");\n\t\tasync function f() {\n\t\t\ttry {\n\t\t\t\tconst res = await fetch(\"/ping\");\n\t\t\t\tawait res.text();\n\t\t\t\tlocation.reload();\n\t\t\t} catch () {\n\t\t\t\tsetTimeout(f, 200);\n\t\t\t}\n\t\t};\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<script type=\"module\">\n\t\tlet data = undefined;\n\t\tlet es = new EventSource(\"/dev/auto-reload\");\n\t\tasync function f() {\n\t\t\ttry {\n\t\t\t\tconst res = await fetch(\"/ping\");\n\t\t\t\tawait res.text();\n\t\t\t\tlocation.reload();\n\t\t\t} catch (_) {\n\t\t\t\tsetTimeout(f, 200);\n\t\t\t}\n\t\t};\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/templates/layout.templ
+++ b/templates/layout.templ
@@ -56,11 +56,9 @@ templ page(navItems templ.Component) {
 	}
 }
 
-templ nav(includeAdmin bool) {
+templ nav() {
 	<a href="/account">Account</a>
-	if includeAdmin {
-		@adminNav()
-	}
+	@adminNav()
 	<a href="/logout">Log out</a>
 }
 

--- a/templates/layout_templ.go
+++ b/templates/layout_templ.go
@@ -139,7 +139,7 @@ func page(navItems templ.Component) templ.Component {
 	})
 }
 
-func nav(includeAdmin bool) templ.Component {
+func nav() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -160,15 +160,13 @@ func nav(includeAdmin bool) templ.Component {
 			templ_7745c5c3_Var4 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<a href=\"/account\">Account</a> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<a href=\"/account\">Account</a>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if includeAdmin {
-			templ_7745c5c3_Err = adminNav().Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
+		templ_7745c5c3_Err = adminNav().Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<a href=\"/logout\">Log out</a>")
 		if templ_7745c5c3_Err != nil {

--- a/templates/user.templ
+++ b/templates/user.templ
@@ -28,8 +28,8 @@ templ Index(devLogin func() templ.Component) {
 	}
 }
 
-templ Account(user models.User, passkeys []models.Passkey, isAdmin bool) {
-	@page(nav(isAdmin)) {
+templ Account(user models.User, passkeys []models.Passkey) {
+	@page(nav()) {
 		<div class="p-8 flex flex-col gap-8">
 			@AccountSettingsForm(user, nil)
 			@PasskeySettings(passkeys)

--- a/templates/user_templ.go
+++ b/templates/user_templ.go
@@ -72,7 +72,7 @@ func Index(devLogin func() templ.Component) templ.Component {
 	})
 }
 
-func Account(user models.User, passkeys []models.Passkey, isAdmin bool) templ.Component {
+func Account(user models.User, passkeys []models.Passkey) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -123,7 +123,7 @@ func Account(user models.User, passkeys []models.Passkey, isAdmin bool) templ.Co
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = page(nav(isAdmin)).Render(templ.WithChildren(ctx, templ_7745c5c3_Var4), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = page(nav()).Render(templ.WithChildren(ctx, templ_7745c5c3_Var4), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
Also made it more granular. The permissions are defined at https://github.com/datasektionen/sso/blob/387c4a781df690b38fbe8c06e816bab2ce91b5cc/pkg/hive/hive.go#L35-L42

Those with type bool are unscoped and those with type `PermissionScopes` (which is a wrapper for a a list of strings) are scoped.

The permissions are now also stored in the session and only fetched from Hive when logging in. The downside of this is that each time someone logs in, we fetch the Hive permissions, but they are not used if SSO is just used as an OIDC provider.

I have yet to implement hiding buttons you may not click when lacking the relevant write permissions.

I decided to use some reflection to get and set the correct field from the permissions struct by the name as defined in Hive. Not sure about the performance of that.