### PR TITLE
Add picture scope and picture option on internal api

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ user info stuff, SSO supports some custom scopes:
   for each OIDC client in SSO's admin panel. The value follows the same format as the body in the
   [`/user/{username}/permissions`](https://hive.datasektionen.se/api/v1/docs#get-/user/-username-/permissions)
   endpoint in Hive's API.
+- `picture`: will make the returned profile claim contain a link to the users profile picture. Note,
+  the link should not be stored because it cannot be garanteed to be valid for more than 24 hours.
 
 ---
 
@@ -41,14 +43,23 @@ The url query parameter `format` determines how the users are returned:
   Requested non-existing users are represented by empty json objects.
 - `map`: The response body will contain a json object with keys being usernames and values being
   objects as explained in `single`. Requested non-existing users will not be present in the response.
+The url query parameter `picture` determines the type of image that is returened per user:
+- `none`: No link is returned (the field is ommited). This is the default option.
+- `thumbnail`: Link to a smaller lower quality picture coresponding to [rfinger](https://rfinger.datasektionen.se/docs/api) `quality=false`
+- `full`: Link to a picture with its original quality coresponding to [rfinger](https://rfinger.datasektionen.se/docs/api) `quality=true`
 
 `GET /api/search`: Retrives user information (kthid, email, first name, family name, year tag) by searching
 their kthid, first name and family name.
-The url paramaters:
+The following url paramaters are used to limit the search:
 - `query` is used for the search term (if omited return all members)
 - `limit` for the number of entries returned (defaults to 5)
 - `offset` for the number of entries to skip (defaults to 0)
 - `year` to limit the search to a specific year, formated as a year tag (if omited search all years)
+
+The url query parameter `picture` optionaly adds an addition field to the response:
+- `none`: No link is returned (the field is ommited). This is the default option.
+- `thumbnail`: Link to a smaller lower quality picture coresponding to [rfinger](https://rfinger.datasektionen.se/docs/api) `quality=false`
+- `full`: Link to a picture with its original quality coresponding to [rfinger](https://rfinger.datasektionen.se/docs/api) `quality=true`
 
 ## Development
 

--- a/job.nomad.hcl
+++ b/job.nomad.hcl
@@ -55,6 +55,7 @@ OIDC_PROVIDER_KEY={{ .oidc_provider_key }}
 DATABASE_URL=postgresql://sso:{{ .database_password }}@postgres.dsekt.internal:5432/sso
 SPAM_API_KEY={{ .spam_api_key }}
 HIVE_API_KEY={{ .hive_api_key }}
+RFINGER_API_KEY={{ .rfinger_api_key }}
 {{ end }}
 
 KTH_ISSUER_URL=https://login.ug.kth.se/adfs
@@ -69,6 +70,7 @@ LDAP_PROXY_URL=http://ldap-proxy.dsekt.internal:38980
 PLS_URL=https://pls.datasektionen.se
 HIVE_URL=http://hive.nomad.dsekt.internal
 SPAM_URL=https://spam.datasektionen.se
+RFINGER_URL=https://rfinger.datasektionen.se
 ENV
         destination = "local/.env"
         env         = true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,8 @@ type Cfg struct {
 	HiveAPIKey            string
 	SpamURL               *url.URL
 	SpamAPIKey            string
+	RfingerURL            *url.URL
+	RfingerAPIKey         string
 }
 
 var Config Cfg
@@ -47,6 +49,8 @@ func init() {
 		HiveAPIKey:            os.Getenv("HIVE_API_KEY"),
 		SpamURL:               getURL("SPAM_URL", true),
 		SpamAPIKey:            os.Getenv("SPAM_API_KEY"),
+		RfingerURL:            getURL("RFINGER_URL", true),
+		RfingerAPIKey:         os.Getenv("RFINGER_API_KEY"),
 	}
 }
 

--- a/pkg/rfinger/rfinger.go
+++ b/pkg/rfinger/rfinger.go
@@ -1,0 +1,88 @@
+package rfinger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+
+	"github.com/datasektionen/sso/pkg/config"
+)
+
+func GetPicture(ctx context.Context, kthid string, quality bool) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(
+		"%s/api/%s?quality=%t",
+		config.Config.RfingerURL.String(),
+		url.PathEscape(kthid),
+		quality,
+	), nil)
+
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+config.Config.RfingerAPIKey)
+	slog.Info("rfinger getPicture", "rfinger_url", config.Config.RfingerURL.String(), "url", req.URL)
+	resp, err := http.DefaultClient.Do(req)
+
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Unexpected status code from rfinger: %d", resp.StatusCode)
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+
+	if err != nil {
+		return "", err
+	}
+
+	body := string(bodyBytes)
+
+	return body, nil
+}
+
+func GetPictures(ctx context.Context, kthid []string, quality bool) (map[string]string, error) {
+	queryBody, err := json.Marshal(kthid)
+
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf(
+		"%s/api/batch?quality=%t",
+		config.Config.RfingerURL.String(),
+		quality,
+	), bytes.NewBuffer([]byte(queryBody)))
+
+	req.Header.Set("Authorization", "Bearer "+config.Config.RfingerAPIKey)
+
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("rfinger getPicture", "rfinger_url", config.Config.RfingerURL.String(), "url", req.URL)
+	resp, err := http.DefaultClient.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Unexpected status code from rfinger: %d", resp.StatusCode)
+	}
+
+	var body map[string]string
+
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("Invalid JSON from rfinger: %w", err)
+	}
+
+	return body, nil
+}

--- a/pkg/static/public/style.dist.css
+++ b/pkg/static/public/style.dist.css
@@ -1,4 +1,4 @@
-/*! tailwindcss v4.1.12 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v4.1.17 | MIT License | https://tailwindcss.com */
 @import "https://www.nerdfonts.com/assets/css/webfont.css";
 @layer properties;
 @layer theme, base, components, utilities;
@@ -669,7 +669,6 @@
   .checked\:after\:content-\[\'✓\'\] {
     &:checked {
       &::after {
-        content: var(--tw-content);
         --tw-content: '✓';
         content: var(--tw-content);
       }


### PR DESCRIPTION
- Would make migrations to rfinger simpler
- Would make systems that only use a profile picture of current user or search users simpler and more efficient